### PR TITLE
Could x-springboot:x-springboot:5.0 drop off redundant dependencies?

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,11 +49,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-configuration-processor</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>
 		<dependency>
@@ -85,6 +80,16 @@
 			<groupId>com.baomidou</groupId>
 			<artifactId>mybatis-plus-extension</artifactId>
 			<version>${mybatis-plus.version}</version>
+			<exclusions>
+				<exclusion>
+					  <artifactId>annotations</artifactId>
+					  <groupId>org.jetbrains</groupId>
+				</exclusion>
+				<exclusion>
+					  <artifactId>kotlin-stdlib-jdk7</artifactId>
+					  <groupId>org.jetbrains.kotlin</groupId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<!--mybatis-->
 		<dependency>
@@ -97,6 +102,12 @@
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
 			<version>${mysql.version}</version>
+			<exclusions>
+				<exclusion>
+					  <artifactId>protobuf-java</artifactId>
+					  <groupId>com.google.protobuf</groupId>
+				</exclusion>
+			      </exclusions>
 		</dependency>
 
 		<!--代码生成模板引擎-->
@@ -155,6 +166,16 @@
 			<groupId>io.springfox</groupId>
 			<artifactId>springfox-boot-starter</artifactId>
 			<version>${swagger.version}</version>
+			<exclusions>
+				<exclusion>
+					  <artifactId>byte-buddy</artifactId>
+					  <groupId>net.bytebuddy</groupId>
+				</exclusion>
+				<exclusion>
+					  <artifactId>classgraph</artifactId>
+					  <groupId>io.github.classgraph</groupId>
+				</exclusion>
+		      </exclusions>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/126549527/232998467-01ab7642-596b-45b3-92f4-33efc0c18af5.png)
![image](https://user-images.githubusercontent.com/126549527/232998650-c37b1abc-55c5-41f6-84e8-9729c2f23393.png)
![image](https://user-images.githubusercontent.com/126549527/232998864-58553ceb-b170-43d0-889c-4597b064b26c.png)

Hi, I found that **_x-springboot:x-springboot:5.0_**’s pom file introduced **_119_** dependencies. However, among them,**_5_** libraries (**_4%_** have not been used by your project), the redundant dependencies are listed below.

More seriously, **_1_**  redundant library has not been maintained by developers for more than **_3_** years (outdated dependencies).

Reduce these unused dependencies can help prevent introducing bugs/vulnerabilities from dependencies with outdated. Meanwhile, it can minimize the project size. To safely remove redundant dependencies, I constructed a complete call graph (resolved most of Java reflection and dynamic binding), and validated that they have not been used by the client code. 

This PR **_x-springboot:x-springboot:5.0_** for removing the redundant dependencies have passed the tests.

Best regards

## Redundant dependencies
#### Redundant direct dependencies:
        org.springframework.boot:spring-boot-configuration-processor:2.7.7:compile [116 KB]
#### Redundant indirect dependencies:
        org.jetbrains:annotations:13.0:compile [17 KB]
        net.bytebuddy:byte-buddy:1.12.20:compile [3 MB]
        org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.6.21:compile [23 KB]
        io.github.classgraph:classgraph:4.8.83:compile [492 KB]

## Outdated dependencies
org.jetbrains:annotations:13.0 (**_3410_** days without maintenance)
